### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, main ]


### PR DESCRIPTION
Potential fix for [https://github.com/gp8938/Java-DSP/security/code-scanning/2](https://github.com/gp8938/Java-DSP/security/code-scanning/2)

In general, the fix is to explicitly declare a restrictive `permissions` block, either at the workflow root (applying to all jobs) or on the specific job, granting only the scopes required. This overrides any broader default repository/organization permissions for `GITHUB_TOKEN`.

For this specific workflow, the job only checks out code, sets up Java, runs Maven build/tests, generates reports, and uploads artifacts. None of these steps require write access to repository contents, issues, or pull requests. Therefore, we can safely set `permissions: contents: read` at the workflow level so it applies to the `build` job. The minimal, non-breaking change is to insert a `permissions:` block near the top of `.github/workflows/build-and-test.yml`, just after the `name:` (line 1) and before `on:` (line 3). No additional imports or methods are required since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
